### PR TITLE
Add Docker support and SQL Server configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+
+RUN dotnet tool install --global dotnet-ef --version 8.0.8
+ENV PATH="$PATH:/root/.dotnet/tools"
+
+WORKDIR /app
+
+COPY src/Parking.Api/Parking.Api.csproj src/Parking.Api/
+COPY src/Parking.Application/Parking.Application.csproj src/Parking.Application/
+COPY src/Parking.Domain/Parking.Domain.csproj src/Parking.Domain/
+COPY src/Parking.Infrastructure/Parking.Infrastructure.csproj src/Parking.Infrastructure/
+
+RUN dotnet restore src/Parking.Api/Parking.Api.csproj
+
+COPY . .
+
+RUN dotnet publish src/Parking.Api/Parking.Api.csproj -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+
+WORKDIR /app
+
+COPY --from=build /app/publish .
+
+EXPOSE 8080
+EXPOSE 8081
+
+ENTRYPOINT ["dotnet", "Parking.Api.dll"]

--- a/README.md
+++ b/README.md
@@ -54,3 +54,28 @@ dotnet test
 ```
 
 Os testes cobrem o cálculo acumulativo de tarifas para garantir a regra de negócio proposta.
+
+## Executando com Docker
+
+### Imagem da API
+
+O repositório inclui um `Dockerfile` baseado no .NET 8 SDK/ASP.NET que restaura as dependências, publica a aplicação e expõe as portas padrão (`8080` e `8081`). Para gerar a imagem execute:
+
+```bash
+docker build -t parking-api .
+```
+
+### Subindo API e banco com Docker Compose
+
+O arquivo `docker-compose.yml` define dois serviços:
+
+- **db**: SQL Server 2022 com um _healthcheck_ que aguarda o banco estar pronto antes de liberar a API. A senha padrão (`Your_strong_password123`) deve ser alterada em produção.
+- **api**: a aplicação ASP.NET configurada para usar SQL Server quando as variáveis `Database__Provider` e `ConnectionStrings__DefaultConnection` são definidas.
+
+Para subir ambos os serviços execute:
+
+```bash
+docker compose up --build
+```
+
+A API ficará disponível em `http://localhost:8080` quando o banco estiver saudável.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.9"
+
+services:
+  db:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    container_name: parking-db
+    environment:
+      ACCEPT_EULA: "Y"
+      SA_PASSWORD: "Your_strong_password123"
+    ports:
+      - "1433:1433"
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Your_strong_password123 -Q 'SELECT 1' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: parking-api
+    environment:
+      ASPNETCORE_ENVIRONMENT: "Production"
+      ASPNETCORE_URLS: "http://+:8080"
+      Database__Provider: "SqlServer"
+      ConnectionStrings__DefaultConnection: "Server=db,1433;Database=ParkingDb;User Id=sa;Password=Your_strong_password123;TrustServerCertificate=True;"
+    ports:
+      - "8080:8080"
+    depends_on:
+      db:
+        condition: service_healthy

--- a/src/Parking.Api/appsettings.json
+++ b/src/Parking.Api/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Database": {
+    "Name": "ParkingDb"
+  }
 }

--- a/src/Parking.Infrastructure/DependencyInjection.cs
+++ b/src/Parking.Infrastructure/DependencyInjection.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +14,23 @@ public static class DependencyInjection
     {
         services.AddDbContext<ParkingDbContext>(options =>
         {
+            var provider = configuration["Database:Provider"];
+            var connectionString = configuration.GetConnectionString("DefaultConnection")
+                                    ?? configuration["Database:ConnectionString"];
+
+            if (!string.IsNullOrWhiteSpace(provider)
+                && provider.Equals("SqlServer", StringComparison.OrdinalIgnoreCase))
+            {
+                if (string.IsNullOrWhiteSpace(connectionString))
+                {
+                    throw new InvalidOperationException(
+                        "A connection string must be provided when using the SQL Server provider.");
+                }
+
+                options.UseSqlServer(connectionString);
+                return;
+            }
+
             var databaseName = configuration["Database:Name"] ?? "ParkingDb";
             options.UseInMemoryDatabase(databaseName);
         });

--- a/src/Parking.Infrastructure/Parking.Infrastructure.csproj
+++ b/src/Parking.Infrastructure/Parking.Infrastructure.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.9" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile to build and publish the ASP.NET API
- provide a docker-compose environment with SQL Server and service healthcheck
- enable selecting SQL Server via configuration and document the new workflow

## Testing
- ⚠️ `dotnet test` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ebfaca94833396083860b328f82a