### PR TITLE
Add ticket inspection loading strategy endpoints

### DIFF
--- a/src/Parking.Api/Controllers/EagerLoadingRoute.md
+++ b/src/Parking.Api/Controllers/EagerLoadingRoute.md
@@ -1,0 +1,3 @@
+# Rota `GET /api/tickets/{ticketId}/inspection-strategies/eager`
+
+A rota exemplifica **Eager Loading**, incluindo a vistoria imediatamente na consulta com `Include`. É ideal para relatórios completos ou integrações que precisam sempre do ticket com a vistoria (por exemplo, exportar para auditoria), evitando round-trips adicionais e garantindo consistência dos dados retornados.

--- a/src/Parking.Api/Controllers/ExplicitLoadingRoute.md
+++ b/src/Parking.Api/Controllers/ExplicitLoadingRoute.md
@@ -1,0 +1,3 @@
+# Rota `GET /api/tickets/{ticketId}/inspection-strategies/explicit`
+
+Aqui utilizamos **Explicit Loading**, buscando o ticket primeiro e carregando a vistoria somente quando a aplicação decide que é necessário. Essa estratégia é útil em cenários em que múltiplas entidades relacionadas podem ser carregadas seletivamente de acordo com regras de negócio (por exemplo, backoffice que analisa várias entidades, mas só busca a vistoria quando o ticket está encerrado).

--- a/src/Parking.Api/Controllers/LazyLoadingRoute.md
+++ b/src/Parking.Api/Controllers/LazyLoadingRoute.md
@@ -1,0 +1,3 @@
+# Rota `GET /api/tickets/{ticketId}/inspection-strategies/lazy`
+
+Esta rota demonstra **Lazy Loading** para recuperar a vistoria associada a um ticket. A consulta busca apenas o ticket e deixa que o Entity Framework carregue a vistoria sob demanda quando o controlador precisa projetar a resposta. Essa abordagem reduz o custo inicial quando o consumidor pode, eventualmente, ignorar os dados relacionados (por exemplo, um painel que inicialmente mostra apenas os dados do ticket e carrega a vistoria somente quando o usuário expande os detalhes).

--- a/src/Parking.Api/Controllers/TicketLoadingStrategiesController.cs
+++ b/src/Parking.Api/Controllers/TicketLoadingStrategiesController.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Mvc;
+using Parking.Api.Mappings;
+using Parking.Api.Models.Responses;
+using Parking.Application.Abstractions;
+
+namespace Parking.Api.Controllers;
+
+[ApiController]
+[Route("api/tickets/{ticketId:guid}/inspection-strategies")]
+public sealed class TicketLoadingStrategiesController : ControllerBase
+{
+    private readonly ITicketDetailsService _ticketDetailsService;
+
+    public TicketLoadingStrategiesController(ITicketDetailsService ticketDetailsService)
+    {
+        _ticketDetailsService = ticketDetailsService ?? throw new ArgumentNullException(nameof(ticketDetailsService));
+    }
+
+    [HttpGet("lazy")]
+    [ProducesResponseType(typeof(ParkingTicketDetailsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ParkingTicketDetailsResponse>> GetWithLazyLoadingAsync(Guid ticketId, CancellationToken cancellationToken)
+    {
+        var details = await _ticketDetailsService.GetWithLazyLoadingAsync(ticketId, cancellationToken);
+        return details is null
+            ? NotFound()
+            : Ok(details.ToResponse("Lazy Loading"));
+    }
+
+    [HttpGet("eager")]
+    [ProducesResponseType(typeof(ParkingTicketDetailsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ParkingTicketDetailsResponse>> GetWithEagerLoadingAsync(Guid ticketId, CancellationToken cancellationToken)
+    {
+        var details = await _ticketDetailsService.GetWithEagerLoadingAsync(ticketId, cancellationToken);
+        return details is null
+            ? NotFound()
+            : Ok(details.ToResponse("Eager Loading"));
+    }
+
+    [HttpGet("explicit")]
+    [ProducesResponseType(typeof(ParkingTicketDetailsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ParkingTicketDetailsResponse>> GetWithExplicitLoadingAsync(Guid ticketId, CancellationToken cancellationToken)
+    {
+        var details = await _ticketDetailsService.GetWithExplicitLoadingAsync(ticketId, cancellationToken);
+        return details is null
+            ? NotFound()
+            : Ok(details.ToResponse("Explicit Loading"));
+    }
+}

--- a/src/Parking.Api/Mappings/TicketDetailsMappingExtensions.cs
+++ b/src/Parking.Api/Mappings/TicketDetailsMappingExtensions.cs
@@ -1,0 +1,22 @@
+using Parking.Api.Models.Responses;
+using Parking.Application.Dtos;
+
+namespace Parking.Api.Mappings;
+
+internal static class TicketDetailsMappingExtensions
+{
+    public static ParkingTicketDetailsResponse ToResponse(this ParkingTicketDetailsDto dto, string strategy)
+    {
+        if (dto is null)
+        {
+            throw new ArgumentNullException(nameof(dto));
+        }
+
+        return new ParkingTicketDetailsResponse
+        {
+            Ticket = dto.Ticket.ToResponse(),
+            Inspection = dto.Inspection?.ToResponse(),
+            LoadingStrategy = strategy
+        };
+    }
+}

--- a/src/Parking.Api/Models/Responses/ParkingTicketDetailsResponse.cs
+++ b/src/Parking.Api/Models/Responses/ParkingTicketDetailsResponse.cs
@@ -1,0 +1,10 @@
+namespace Parking.Api.Models.Responses;
+
+public sealed record ParkingTicketDetailsResponse
+{
+    public required ParkingTicketResponse Ticket { get; init; }
+
+    public VehicleInspectionResponse? Inspection { get; init; }
+
+    public required string LoadingStrategy { get; init; }
+}

--- a/src/Parking.Application/Abstractions/ITicketDetailsService.cs
+++ b/src/Parking.Application/Abstractions/ITicketDetailsService.cs
@@ -1,0 +1,12 @@
+using Parking.Application.Dtos;
+
+namespace Parking.Application.Abstractions;
+
+public interface ITicketDetailsService
+{
+    Task<ParkingTicketDetailsDto?> GetWithLazyLoadingAsync(Guid ticketId, CancellationToken cancellationToken = default);
+
+    Task<ParkingTicketDetailsDto?> GetWithEagerLoadingAsync(Guid ticketId, CancellationToken cancellationToken = default);
+
+    Task<ParkingTicketDetailsDto?> GetWithExplicitLoadingAsync(Guid ticketId, CancellationToken cancellationToken = default);
+}

--- a/src/Parking.Application/DependencyInjection.cs
+++ b/src/Parking.Application/DependencyInjection.cs
@@ -15,6 +15,8 @@ public static class DependencyInjection
 
         services.AddScoped<IVehicleInspectionService, VehicleInspectionService>();
 
+        services.AddScoped<ITicketDetailsService, TicketDetailsService>();
+
         services.AddSingleton<IParkingFeeCalculator, ParkingFeeCalculator>();
         return services;
     }

--- a/src/Parking.Application/Dtos/ParkingTicketDetailsDto.cs
+++ b/src/Parking.Application/Dtos/ParkingTicketDetailsDto.cs
@@ -1,0 +1,8 @@
+namespace Parking.Application.Dtos;
+
+public sealed record ParkingTicketDetailsDto
+{
+    public required ParkingTicketDto Ticket { get; init; }
+
+    public VehicleInspectionDto? Inspection { get; init; }
+}

--- a/src/Parking.Application/Mappings/ParkingTicketDetailsMappingExtensions.cs
+++ b/src/Parking.Application/Mappings/ParkingTicketDetailsMappingExtensions.cs
@@ -1,0 +1,21 @@
+using Parking.Application.Dtos;
+using Parking.Domain.Entities;
+
+namespace Parking.Application.Mappings;
+
+internal static class ParkingTicketDetailsMappingExtensions
+{
+    public static ParkingTicketDetailsDto ToDetailsDto(this ParkingTicket ticket)
+    {
+        if (ticket is null)
+        {
+            throw new ArgumentNullException(nameof(ticket));
+        }
+
+        return new ParkingTicketDetailsDto
+        {
+            Ticket = ticket.ToDto(),
+            Inspection = ticket.Inspection?.ToDto()
+        };
+    }
+}

--- a/src/Parking.Application/Services/TicketDetailsService.cs
+++ b/src/Parking.Application/Services/TicketDetailsService.cs
@@ -1,0 +1,49 @@
+using Parking.Application.Abstractions;
+using Parking.Application.Dtos;
+using Parking.Application.Mappings;
+using Parking.Domain.Repositories;
+
+namespace Parking.Application.Services;
+
+public sealed class TicketDetailsService : ITicketDetailsService
+{
+    private readonly IParkingTicketRepository _ticketRepository;
+
+    public TicketDetailsService(IParkingTicketRepository ticketRepository)
+    {
+        _ticketRepository = ticketRepository ?? throw new ArgumentNullException(nameof(ticketRepository));
+    }
+
+    public async Task<ParkingTicketDetailsDto?> GetWithLazyLoadingAsync(Guid ticketId, CancellationToken cancellationToken = default)
+    {
+        if (ticketId == Guid.Empty)
+        {
+            return null;
+        }
+
+        var ticket = await _ticketRepository.GetByIdWithInspectionLazyAsync(ticketId, cancellationToken);
+        return ticket?.ToDetailsDto();
+    }
+
+    public async Task<ParkingTicketDetailsDto?> GetWithEagerLoadingAsync(Guid ticketId, CancellationToken cancellationToken = default)
+    {
+        if (ticketId == Guid.Empty)
+        {
+            return null;
+        }
+
+        var ticket = await _ticketRepository.GetByIdWithInspectionEagerAsync(ticketId, cancellationToken);
+        return ticket?.ToDetailsDto();
+    }
+
+    public async Task<ParkingTicketDetailsDto?> GetWithExplicitLoadingAsync(Guid ticketId, CancellationToken cancellationToken = default)
+    {
+        if (ticketId == Guid.Empty)
+        {
+            return null;
+        }
+
+        var ticket = await _ticketRepository.GetByIdWithInspectionExplicitAsync(ticketId, cancellationToken);
+        return ticket?.ToDetailsDto();
+    }
+}

--- a/src/Parking.Domain/Entities/ParkingTicket.cs
+++ b/src/Parking.Domain/Entities/ParkingTicket.cs
@@ -38,6 +38,8 @@ public class ParkingTicket
 
     public bool IsActive => ExitAt is null;
 
+    public virtual VehicleInspection? Inspection { get; private set; }
+
     public void Close(DateTimeOffset exitAt, decimal totalAmount)
     {
         if (!IsActive)

--- a/src/Parking.Domain/Entities/VehicleInspection.cs
+++ b/src/Parking.Domain/Entities/VehicleInspection.cs
@@ -1,6 +1,6 @@
 namespace Parking.Domain.Entities;
 
-public sealed class VehicleInspection
+public class VehicleInspection
 {
     private VehicleInspection()
     {
@@ -66,7 +66,7 @@ public sealed class VehicleInspection
 
     public string? HarshImpactsPhotoUrl { get; private set; }
 
-    public ParkingTicket? Ticket { get; private set; }
+    public virtual ParkingTicket? Ticket { get; private set; }
 
     public void UpdateChecklist(
         bool noScratches,

--- a/src/Parking.Domain/Repositories/IParkingTicketRepository.cs
+++ b/src/Parking.Domain/Repositories/IParkingTicketRepository.cs
@@ -6,6 +6,12 @@ public interface IParkingTicketRepository
 {
     Task<ParkingTicket?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
 
+    Task<ParkingTicket?> GetByIdWithInspectionLazyAsync(Guid id, CancellationToken cancellationToken = default);
+
+    Task<ParkingTicket?> GetByIdWithInspectionEagerAsync(Guid id, CancellationToken cancellationToken = default);
+
+    Task<ParkingTicket?> GetByIdWithInspectionExplicitAsync(Guid id, CancellationToken cancellationToken = default);
+
     Task<ParkingTicket?> GetActiveByPlateAsync(string plate, CancellationToken cancellationToken = default);
 
     Task<IReadOnlyCollection<ParkingTicket>> GetAllAsync(CancellationToken cancellationToken = default);

--- a/src/Parking.Infrastructure/DependencyInjection.cs
+++ b/src/Parking.Infrastructure/DependencyInjection.cs
@@ -14,6 +14,7 @@ public static class DependencyInjection
     {
         services.AddDbContext<ParkingDbContext>(options =>
         {
+            options.UseLazyLoadingProxies();
             var provider = configuration["Database:Provider"];
             var connectionString = configuration.GetConnectionString("DefaultConnection")
                                     ?? configuration["Database:ConnectionString"];

--- a/src/Parking.Infrastructure/Parking.Infrastructure.csproj
+++ b/src/Parking.Infrastructure/Parking.Infrastructure.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.9" />
   </ItemGroup>
 

--- a/src/Parking.Infrastructure/Persistence/Configurations/VehicleInspectionConfiguration.cs
+++ b/src/Parking.Infrastructure/Persistence/Configurations/VehicleInspectionConfiguration.cs
@@ -32,8 +32,8 @@ public sealed class VehicleInspectionConfiguration : IEntityTypeConfiguration<Ve
             .IsUnique();
 
         builder.HasOne(inspection => inspection.Ticket)
-            .WithMany()
-            .HasForeignKey(inspection => inspection.TicketId)
+            .WithOne(ticket => ticket.Inspection)
+            .HasForeignKey<VehicleInspection>(inspection => inspection.TicketId)
             .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/src/Parking.Infrastructure/Repositories/ParkingTicketRepository.cs
+++ b/src/Parking.Infrastructure/Repositories/ParkingTicketRepository.cs
@@ -47,6 +47,34 @@ public sealed class ParkingTicketRepository : IParkingTicketRepository
             .FirstOrDefaultAsync(ticket => ticket.Id == id, cancellationToken);
     }
 
+    public async Task<ParkingTicket?> GetByIdWithInspectionLazyAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.ParkingTickets
+            .FirstOrDefaultAsync(ticket => ticket.Id == id, cancellationToken);
+    }
+
+    public async Task<ParkingTicket?> GetByIdWithInspectionEagerAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.ParkingTickets
+            .Include(ticket => ticket.Inspection)
+            .FirstOrDefaultAsync(ticket => ticket.Id == id, cancellationToken);
+    }
+
+    public async Task<ParkingTicket?> GetByIdWithInspectionExplicitAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var ticket = await _dbContext.ParkingTickets
+            .FirstOrDefaultAsync(ticket => ticket.Id == id, cancellationToken);
+
+        if (ticket is not null)
+        {
+            await _dbContext.Entry(ticket)
+                .Reference(t => t.Inspection)
+                .LoadAsync(cancellationToken);
+        }
+
+        return ticket;
+    }
+
     public async Task<ParkingTicket?> GetActiveByPlateAsync(string plate, CancellationToken cancellationToken = default)
     {
         return await _dbContext.ParkingTickets


### PR DESCRIPTION
## Summary
- add controller endpoints to expose ticket inspection details using lazy, eager, and explicit loading strategies
- enable EF Core lazy-loading proxies and extend repositories/services to support loading the inspection relation
- document each new route with markdown files explaining when each strategy is beneficial

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d70b9fadc88333b806be2d06d10fa0