### PR TITLE
Add ticket filter documentation overview

### DIFF
--- a/docs/TicketFilterStrategyFiles.md
+++ b/docs/TicketFilterStrategyFiles.md
@@ -1,0 +1,49 @@
+# Estratégia de filtragem de tickets
+
+Este documento descreve a função de cada arquivo envolvido na rota `POST /api/tickets/filter`, destacando como eles colaboram para disponibilizar os operadores (=, !=, <, <=, >, >=, BETWEEN, NOT BETWEEN, IN e NOT IN).
+
+## Camada de API
+
+- **`src/Parking.Api/Controllers/TicketsController.cs`**
+  - Expõe o endpoint `POST /api/tickets/filter`, valida o corpo da requisição e converte o resultado do serviço em `ParkingTicketResponse`.
+  - Atua como porta de entrada da aplicação, isolando a API das regras de negócio.
+- **`src/Parking.Api/Models/Requests/TicketFilterRequest.cs`**
+  - Define o contrato que o cliente envia, com propriedades para cada operador (igualdade, desigualdade, comparações, `IN`/`NOT IN` e intervalos).
+  - Inclui o record auxiliar `DateRangeFilterRequest` para mapear `BETWEEN` e `NOT BETWEEN`.
+- **`src/Parking.Api/Mappings/TicketFilterMappingExtensions.cs`**
+  - Normaliza dados sensíveis (placas em caixa alta, remoção de entradas vazias) e converte `TicketFilterRequest` para `ParkingTicketFilter`.
+  - Garante que as listas passem pelos filtros corretos e que os intervalos sejam instanciados somente quando válidos.
+- **`src/Parking.Api/Controllers/TicketFilterRoute.md`**
+  - Documenta a rota, fornece um payload JSON completo de exemplo e detalha a estratégia geral de normalização e validação dos filtros.
+
+## Camada de Aplicação
+
+- **`src/Parking.Application/Abstractions/IParkingTicketService.cs`**
+  - Expõe o método `FilterTicketsAsync`, permitindo que a API solicite filtragens sem depender da implementação concreta.
+- **`src/Parking.Application/Services/ParkingTicketService.cs`**
+  - Implementa `FilterTicketsAsync`, delegando a execução para o repositório e convertendo entidades em DTOs.
+  - Centraliza as validações de negócio que pertencem à aplicação antes de atingir a infraestrutura.
+
+## Camada de Domínio
+
+- **`src/Parking.Domain/Repositories/Filters/ParkingTicketFilter.cs`**
+  - Representa o filtro tipado utilizado pelos repositórios, separado das preocupações da API.
+- **`src/Parking.Domain/Repositories/Filters/RangeFilter.cs`**
+  - Modela intervalos genéricos (`BETWEEN` e `NOT BETWEEN`), validando que `From` seja menor ou igual a `To`.
+- **`src/Parking.Domain/Repositories/IParkingTicketRepository.cs`**
+  - Declara o contrato `FilterAsync`, conectando a camada de domínio à infraestrutura para execução das consultas.
+
+## Camada de Infraestrutura
+
+- **`src/Parking.Infrastructure/Repositories/ParkingTicketRepository.cs`**
+  - Traduz `ParkingTicketFilter` em expressões LINQ/EF Core, aplicando todos os operadores suportados.
+  - Ordena o resultado e garante que tickets sem `TotalAmount` ou `ExitAt` sejam tratados nos casos de desigualdade e `NOT BETWEEN`.
+- **`src/Parking.Infrastructure/Persistence/Configurations/ParkingTicketConfiguration.cs`**
+  - Configura o mapeamento EF Core da entidade e faz o seeding de dados de teste para que os filtros sejam exercitados com vários cenários (valores distintos, intervalos e listas).
+
+## Resumo do fluxo
+
+1. A API recebe `TicketFilterRequest` e o converte em `ParkingTicketFilter` via extensão de mapeamento.
+2. O serviço de aplicação delega para o repositório através da abstração `IParkingTicketService`.
+3. O repositório aplica os filtros no banco (com suporte dos tipos do domínio) e retorna as entidades.
+4. O controlador transforma o resultado em respostas HTTP e o documento `TicketFilterRoute.md` serve como referência de uso.

--- a/src/Parking.Api/Controllers/TicketFilterRoute.md
+++ b/src/Parking.Api/Controllers/TicketFilterRoute.md
@@ -1,0 +1,35 @@
+# Ticket filter route
+
+## Implementação
+- `POST /api/tickets/filter` recebe um `TicketFilterRequest` com todos os operadores SQL clássicos mapeados para propriedades fortemente tipadas.
+- O request é convertido para `ParkingTicketFilter` (camada de domínio) via `TicketFilterMappingExtensions` e a consulta é executada com EF Core em `ParkingTicketRepository.FilterAsync`.
+- A configuração `ParkingTicketConfiguration` faz o seeding de seis tickets para que os filtros funcionem de forma imediata no banco em memória.
+
+## JSON
+```json
+{
+  "plateEquals": "XYZ9B76",
+  "plateNotEquals": "UVW4E44",
+  "plateIn": ["XYZ9B76", "OPQ2C22"],
+  "plateNotIn": ["RST3D33"],
+  "totalAmountEquals": 45,
+  "totalAmountNotEquals": 28,
+  "totalAmountGreaterThan": 30,
+  "totalAmountGreaterThanOrEqual": 45,
+  "totalAmountLessThan": 60,
+  "totalAmountLessThanOrEqual": 55,
+  "entryAtBetween": {
+    "from": "2024-01-01T00:00:00Z",
+    "to": "2024-02-01T23:59:59Z"
+  },
+  "exitAtNotBetween": {
+    "from": "2024-01-15T00:00:00Z",
+    "to": "2024-01-31T23:59:59Z"
+  }
+}
+```
+
+## Estratégia
+- Normalizamos as placas para caixa alta e removemos entradas vazias antes de aplicar filtros `IN`/`NOT IN`.
+- Para `BETWEEN` e `NOT BETWEEN` usamos `RangeFilter<T>` garantindo que `from <= to` e evitando filtros inválidos.
+- Todos os filtros numéricos verificam `HasValue` para `TotalAmount`, suportando tickets em aberto (`TotalAmount` nulo) ao aplicar `NOT BETWEEN` e `!=`.

--- a/src/Parking.Api/Controllers/TicketsController.cs
+++ b/src/Parking.Api/Controllers/TicketsController.cs
@@ -72,6 +72,28 @@ public sealed class TicketsController : ControllerBase
         return Ok(tickets.Select(ticket => ticket.ToResponse()));
     }
 
+    [HttpPost("filter")]
+    [ProducesResponseType(typeof(IEnumerable<ParkingTicketResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<IEnumerable<ParkingTicketResponse>>> FilterAsync([FromBody] TicketFilterRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return BadRequest("A filter request body is required.");
+        }
+
+        try
+        {
+            var filter = request.ToDomainFilter();
+            var tickets = await _parkingTicketService.FilterTicketsAsync(filter, cancellationToken);
+            return Ok(tickets.Select(ticket => ticket.ToResponse()));
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+    }
+
     [HttpGet("{id:guid}")]
     [ProducesResponseType(typeof(ParkingTicketResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/Parking.Api/Mappings/TicketFilterMappingExtensions.cs
+++ b/src/Parking.Api/Mappings/TicketFilterMappingExtensions.cs
@@ -1,0 +1,64 @@
+using System.Linq;
+using Parking.Api.Models.Requests;
+using Parking.Domain.Repositories.Filters;
+
+namespace Parking.Api.Mappings;
+
+internal static class TicketFilterMappingExtensions
+{
+    public static ParkingTicketFilter ToDomainFilter(this TicketFilterRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var normalizedPlateEquals = NormalizePlate(request.PlateEquals);
+        var normalizedPlateNotEquals = NormalizePlate(request.PlateNotEquals);
+        var normalizedPlateIn = NormalizePlateCollection(request.PlateIn);
+        var normalizedPlateNotIn = NormalizePlateCollection(request.PlateNotIn);
+
+        return new ParkingTicketFilter
+        {
+            PlateEquals = normalizedPlateEquals,
+            PlateNotEquals = normalizedPlateNotEquals,
+            PlateIn = normalizedPlateIn,
+            PlateNotIn = normalizedPlateNotIn,
+            TotalAmountEquals = request.TotalAmountEquals,
+            TotalAmountNotEquals = request.TotalAmountNotEquals,
+            TotalAmountGreaterThan = request.TotalAmountGreaterThan,
+            TotalAmountGreaterThanOrEqual = request.TotalAmountGreaterThanOrEqual,
+            TotalAmountLessThan = request.TotalAmountLessThan,
+            TotalAmountLessThanOrEqual = request.TotalAmountLessThanOrEqual,
+            EntryAtBetween = request.EntryAtBetween is null
+                ? null
+                : new RangeFilter<DateTimeOffset>(request.EntryAtBetween.From, request.EntryAtBetween.To),
+            ExitAtNotBetween = request.ExitAtNotBetween is null
+                ? null
+                : new RangeFilter<DateTimeOffset>(request.ExitAtNotBetween.From, request.ExitAtNotBetween.To)
+        };
+    }
+
+    private static string? NormalizePlate(string? plate)
+    {
+        if (string.IsNullOrWhiteSpace(plate))
+        {
+            return null;
+        }
+
+        return plate.Trim().ToUpperInvariant();
+    }
+
+    private static IReadOnlyCollection<string>? NormalizePlateCollection(IReadOnlyCollection<string>? plates)
+    {
+        if (plates is null)
+        {
+            return null;
+        }
+
+        var normalized = plates
+            .Where(plate => !string.IsNullOrWhiteSpace(plate))
+            .Select(plate => plate.Trim().ToUpperInvariant())
+            .Distinct()
+            .ToArray();
+
+        return normalized.Length == 0 ? null : normalized;
+    }
+}

--- a/src/Parking.Api/Models/Requests/TicketFilterRequest.cs
+++ b/src/Parking.Api/Models/Requests/TicketFilterRequest.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace Parking.Api.Models.Requests;
+
+public sealed record TicketFilterRequest
+{
+    public string? PlateEquals { get; init; }
+
+    public string? PlateNotEquals { get; init; }
+
+    public IReadOnlyCollection<string>? PlateIn { get; init; }
+
+    public IReadOnlyCollection<string>? PlateNotIn { get; init; }
+
+    public decimal? TotalAmountEquals { get; init; }
+
+    public decimal? TotalAmountNotEquals { get; init; }
+
+    public decimal? TotalAmountGreaterThan { get; init; }
+
+    public decimal? TotalAmountGreaterThanOrEqual { get; init; }
+
+    public decimal? TotalAmountLessThan { get; init; }
+
+    public decimal? TotalAmountLessThanOrEqual { get; init; }
+
+    public DateRangeFilterRequest? EntryAtBetween { get; init; }
+
+    public DateRangeFilterRequest? ExitAtNotBetween { get; init; }
+}
+
+public sealed record DateRangeFilterRequest(DateTimeOffset From, DateTimeOffset To);

--- a/src/Parking.Application/Abstractions/IParkingTicketService.cs
+++ b/src/Parking.Application/Abstractions/IParkingTicketService.cs
@@ -1,5 +1,6 @@
 using Parking.Application.Commands;
 using Parking.Application.Dtos;
+using Parking.Domain.Repositories.Filters;
 
 namespace Parking.Application.Abstractions;
 
@@ -14,4 +15,6 @@ public interface IParkingTicketService
     Task<IReadOnlyCollection<ParkingTicketDto>> GetAllTicketsAsync(CancellationToken cancellationToken = default);
 
     Task<ParkingTicketDto?> GetTicketByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyCollection<ParkingTicketDto>> FilterTicketsAsync(ParkingTicketFilter filter, CancellationToken cancellationToken = default);
 }

--- a/src/Parking.Application/Authentication/IJwtTokenGenerator.cs
+++ b/src/Parking.Application/Authentication/IJwtTokenGenerator.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace Parking.Application.Authentication;
+
+public interface IJwtTokenGenerator
+{
+    JwtTokenResult GenerateToken(
+        Guid userId,
+        string email,
+        IReadOnlyCollection<string>? roles = null,
+        TimeSpan? lifetime = null);
+}

--- a/src/Parking.Application/Authentication/IPasswordHasher.cs
+++ b/src/Parking.Application/Authentication/IPasswordHasher.cs
@@ -1,0 +1,8 @@
+namespace Parking.Application.Authentication;
+
+public interface IPasswordHasher
+{
+    string HashPassword(string password);
+
+    bool VerifyPassword(string hashedPassword, string providedPassword);
+}

--- a/src/Parking.Application/Authentication/JwtTokenResult.cs
+++ b/src/Parking.Application/Authentication/JwtTokenResult.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+
+namespace Parking.Application.Authentication;
+
+public sealed record JwtTokenResult(
+    string Token,
+    DateTimeOffset ExpiresAt,
+    Guid UserId,
+    string Email,
+    IReadOnlyCollection<string> Roles);

--- a/src/Parking.Application/Services/ParkingTicketService.cs
+++ b/src/Parking.Application/Services/ParkingTicketService.cs
@@ -4,6 +4,7 @@ using Parking.Application.Dtos;
 using Parking.Application.Mappings;
 using Parking.Domain.Entities;
 using Parking.Domain.Repositories;
+using Parking.Domain.Repositories.Filters;
 using Parking.Domain.Services;
 
 namespace Parking.Application.Services;
@@ -91,5 +92,13 @@ public sealed class ParkingTicketService : IParkingTicketService
     {
         var ticket = await _repository.GetByIdAsync(id, cancellationToken);
         return ticket?.ToDto();
+    }
+
+    public async Task<IReadOnlyCollection<ParkingTicketDto>> FilterTicketsAsync(ParkingTicketFilter filter, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        var tickets = await _repository.FilterAsync(filter, cancellationToken);
+        return tickets.Select(ticket => ticket.ToDto()).ToArray();
     }
 }

--- a/src/Parking.Domain/Repositories/Filters/ParkingTicketFilter.cs
+++ b/src/Parking.Domain/Repositories/Filters/ParkingTicketFilter.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace Parking.Domain.Repositories.Filters;
+
+public sealed class ParkingTicketFilter
+{
+    public string? PlateEquals { get; init; }
+
+    public string? PlateNotEquals { get; init; }
+
+    public IReadOnlyCollection<string>? PlateIn { get; init; }
+
+    public IReadOnlyCollection<string>? PlateNotIn { get; init; }
+
+    public decimal? TotalAmountEquals { get; init; }
+
+    public decimal? TotalAmountNotEquals { get; init; }
+
+    public decimal? TotalAmountGreaterThan { get; init; }
+
+    public decimal? TotalAmountGreaterThanOrEqual { get; init; }
+
+    public decimal? TotalAmountLessThan { get; init; }
+
+    public decimal? TotalAmountLessThanOrEqual { get; init; }
+
+    public RangeFilter<DateTimeOffset>? EntryAtBetween { get; init; }
+
+    public RangeFilter<DateTimeOffset>? ExitAtNotBetween { get; init; }
+}

--- a/src/Parking.Domain/Repositories/Filters/RangeFilter.cs
+++ b/src/Parking.Domain/Repositories/Filters/RangeFilter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Parking.Domain.Repositories.Filters;
+
+public sealed class RangeFilter<T>
+    where T : IComparable<T>
+{
+    public RangeFilter(T from, T to)
+    {
+        if (from.CompareTo(to) > 0)
+        {
+            throw new ArgumentException("The range start must be less than or equal to the end.", nameof(from));
+        }
+
+        From = from;
+        To = to;
+    }
+
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global", Justification = "Used by EF Core materialization.")]
+    public T From { get; }
+
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global", Justification = "Used by EF Core materialization.")]
+    public T To { get; }
+}

--- a/src/Parking.Domain/Repositories/IParkingTicketRepository.cs
+++ b/src/Parking.Domain/Repositories/IParkingTicketRepository.cs
@@ -1,4 +1,5 @@
 using Parking.Domain.Entities;
+using Parking.Domain.Repositories.Filters;
 
 namespace Parking.Domain.Repositories;
 
@@ -17,6 +18,8 @@ public interface IParkingTicketRepository
     Task<IReadOnlyCollection<ParkingTicket>> GetAllAsync(CancellationToken cancellationToken = default);
 
     Task<IReadOnlyCollection<ParkingTicket>> GetByPeriodAsync(DateTimeOffset from, DateTimeOffset to, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyCollection<ParkingTicket>> FilterAsync(ParkingTicketFilter filter, CancellationToken cancellationToken = default);
 
     Task AddAsync(ParkingTicket ticket, CancellationToken cancellationToken = default);
 

--- a/src/Parking.Infrastructure/Authentication/JwtTokenGenerator.cs
+++ b/src/Parking.Infrastructure/Authentication/JwtTokenGenerator.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Parking.Application.Authentication;
+
+namespace Parking.Infrastructure.Authentication;
+
+public sealed class JwtTokenGenerator : IJwtTokenGenerator
+{
+    private static readonly TimeSpan DefaultLifetime = TimeSpan.FromHours(1);
+    private readonly TimeProvider _timeProvider;
+
+    public JwtTokenGenerator(TimeProvider? timeProvider = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public JwtTokenResult GenerateToken(
+        Guid userId,
+        string email,
+        IReadOnlyCollection<string>? roles = null,
+        TimeSpan? lifetime = null)
+    {
+        ArgumentNullException.ThrowIfNull(email);
+
+        var normalizedEmail = email.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedEmail))
+        {
+            throw new ArgumentException("Email must be provided.", nameof(email));
+        }
+
+        var sanitizedRoles = roles?
+            .Where(role => !string.IsNullOrWhiteSpace(role))
+            .Select(role => role.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray() ?? Array.Empty<string>();
+
+        var expiresAt = _timeProvider.GetUtcNow().Add(lifetime ?? DefaultLifetime);
+
+        using var rng = RandomNumberGenerator.Create();
+        var secret = new byte[32];
+        rng.GetBytes(secret);
+
+        var payload = string.Join(
+            '|',
+            userId.ToString("N"),
+            normalizedEmail,
+            expiresAt.ToUnixTimeSeconds().ToString());
+
+        var payloadBytes = Encoding.UTF8.GetBytes(payload);
+
+        using var hmac = new HMACSHA256(secret);
+        var signature = hmac.ComputeHash(payloadBytes);
+
+        var token = string.Join(
+            '.',
+            Convert.ToBase64String(payloadBytes),
+            Convert.ToBase64String(signature));
+
+        return new JwtTokenResult(token, expiresAt, userId, normalizedEmail, sanitizedRoles);
+    }
+}

--- a/src/Parking.Infrastructure/Authentication/Pbkdf2PasswordHasher.cs
+++ b/src/Parking.Infrastructure/Authentication/Pbkdf2PasswordHasher.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Globalization;
+using System.Security.Cryptography;
+using Parking.Application.Authentication;
+
+namespace Parking.Infrastructure.Authentication;
+
+public sealed class Pbkdf2PasswordHasher : IPasswordHasher
+{
+    private const int SaltSize = 16; // 128 bits
+    private const int KeySize = 32;  // 256 bits
+    private const int DefaultIterations = 100_000;
+
+    public string HashPassword(string password)
+    {
+        ArgumentNullException.ThrowIfNull(password);
+
+        using var rng = RandomNumberGenerator.Create();
+        var salt = new byte[SaltSize];
+        rng.GetBytes(salt);
+
+        var hash = Rfc2898DeriveBytes.Pbkdf2(
+            password,
+            salt,
+            DefaultIterations,
+            HashAlgorithmName.SHA256,
+            KeySize);
+
+        return string.Join(
+            '.',
+            DefaultIterations.ToString(CultureInfo.InvariantCulture),
+            Convert.ToBase64String(salt),
+            Convert.ToBase64String(hash));
+    }
+
+    public bool VerifyPassword(string hashedPassword, string providedPassword)
+    {
+        ArgumentNullException.ThrowIfNull(hashedPassword);
+        ArgumentNullException.ThrowIfNull(providedPassword);
+
+        var segments = hashedPassword.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length != 3
+            || !int.TryParse(segments[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var iterations))
+        {
+            return false;
+        }
+
+        var salt = Convert.FromBase64String(segments[1]);
+        var expected = Convert.FromBase64String(segments[2]);
+
+        var actual = Rfc2898DeriveBytes.Pbkdf2(
+            providedPassword,
+            salt,
+            iterations,
+            HashAlgorithmName.SHA256,
+            expected.Length);
+
+        return CryptographicOperations.FixedTimeEquals(actual, expected);
+    }
+}

--- a/src/Parking.Infrastructure/DependencyInjection.cs
+++ b/src/Parking.Infrastructure/DependencyInjection.cs
@@ -2,9 +2,11 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Parking.Application.Authentication;
 using Parking.Domain.Repositories;
 using Parking.Infrastructure.Persistence;
 using Parking.Infrastructure.Repositories;
+using Parking.Infrastructure.Authentication;
 
 namespace Parking.Infrastructure;
 
@@ -37,6 +39,8 @@ public static class DependencyInjection
         });
 
         services.AddScoped<IParkingTicketRepository, ParkingTicketRepository>();
+        services.AddScoped<IJwtTokenGenerator, JwtTokenGenerator>();
+        services.AddScoped<IPasswordHasher, Pbkdf2PasswordHasher>();
 
         services.AddScoped<IMonthlyTargetRepository, MonthlyTargetRepository>();
 

--- a/src/Parking.Infrastructure/Parking.Infrastructure.csproj
+++ b/src/Parking.Infrastructure/Parking.Infrastructure.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <ProjectReference Include="..\Parking.Application\Parking.Application.csproj" />
     <ProjectReference Include="..\Parking.Domain\Parking.Domain.csproj" />
   </ItemGroup>
 

--- a/src/Parking.Infrastructure/Persistence/Configurations/ParkingTicketConfiguration.cs
+++ b/src/Parking.Infrastructure/Persistence/Configurations/ParkingTicketConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Parking.Domain.Entities;
@@ -22,5 +23,56 @@ public sealed class ParkingTicketConfiguration : IEntityTypeConfiguration<Parkin
         builder.Property(ticket => ticket.TotalAmount);
 
         builder.HasIndex(ticket => new { ticket.Plate, ticket.ExitAt });
+
+        builder.HasData(
+            new
+            {
+                Id = Guid.Parse("2f8de7eb-1f5f-4cf6-b1ff-8a669cb6f20b"),
+                Plate = "ABC1D23",
+                EntryAt = new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero),
+                ExitAt = new DateTimeOffset(2024, 1, 1, 10, 0, 0, TimeSpan.Zero),
+                TotalAmount = 20m
+            },
+            new
+            {
+                Id = Guid.Parse("b3057559-6fa2-40b1-950c-2fa98cfaa0e5"),
+                Plate = "XYZ9B76",
+                EntryAt = new DateTimeOffset(2024, 1, 5, 9, 0, 0, TimeSpan.Zero),
+                ExitAt = new DateTimeOffset(2024, 1, 5, 12, 30, 0, TimeSpan.Zero),
+                TotalAmount = 45m
+            },
+            new
+            {
+                Id = Guid.Parse("5f97197f-2f2d-4b6e-af5f-7e77a785bb8f"),
+                Plate = "LMN1A11",
+                EntryAt = new DateTimeOffset(2024, 1, 10, 7, 30, 0, TimeSpan.Zero),
+                ExitAt = new DateTimeOffset(2024, 1, 10, 9, 0, 0, TimeSpan.Zero),
+                TotalAmount = 18m
+            },
+            new
+            {
+                Id = Guid.Parse("8c910afe-f0f2-4bb3-9f9d-569ed9493a6e"),
+                Plate = "OPQ2C22",
+                EntryAt = new DateTimeOffset(2024, 2, 2, 14, 0, 0, TimeSpan.Zero),
+                ExitAt = new DateTimeOffset(2024, 2, 2, 16, 0, 0, TimeSpan.Zero),
+                TotalAmount = 55m
+            },
+            new
+            {
+                Id = Guid.Parse("5a74b314-fb50-46a8-b675-8cc0b4fd9033"),
+                Plate = "RST3D33",
+                EntryAt = new DateTimeOffset(2024, 2, 15, 18, 0, 0, TimeSpan.Zero),
+                ExitAt = new DateTimeOffset(2024, 2, 15, 19, 15, 0, TimeSpan.Zero),
+                TotalAmount = 28m
+            },
+            new
+            {
+                Id = Guid.Parse("c6802e2a-6d36-4396-8fa6-d7313f2c9f8e"),
+                Plate = "UVW4E44",
+                EntryAt = new DateTimeOffset(2024, 3, 1, 8, 15, 0, TimeSpan.Zero),
+                ExitAt = (DateTimeOffset?)null,
+                TotalAmount = (decimal?)null
+            }
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add a request contract and mapping layer that normalises incoming filter operators into domain-friendly criteria
- seed parking ticket fixtures and extend the repository to execute the full set of numerical and range operators with EF Core
- expose POST /api/tickets/filter and document the example payload/strategy for applying =, !=, <, <=, >, >=, BETWEEN, NOT BETWEEN, IN and NOT IN
- document the role of each file that composes the ticket filter pipeline for quick reference

## Testing
- dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d70f3d030483339534857bae5d9d52