### PR TITLE
Fix PBKDF2 password hasher implementation

### DIFF
--- a/src/Parking.Infrastructure/Authentication/Pbkdf2PasswordHasher.cs
+++ b/src/Parking.Infrastructure/Authentication/Pbkdf2PasswordHasher.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Globalization;
 using System.Security.Cryptography;
-using Parking.Application.Authentication;
 using Parking.Application.Abstractions.Security;
-
 
 namespace Parking.Infrastructure.Authentication;
 
@@ -15,7 +13,10 @@ public sealed class Pbkdf2PasswordHasher : IPasswordHasher
 
     public string HashPassword(string password)
     {
-        ArgumentNullException.ThrowIfNull(password);
+        if (string.IsNullOrEmpty(password))
+        {
+            throw new ArgumentException("Password must not be null or empty.", nameof(password));
+        }
 
         using var rng = RandomNumberGenerator.Create();
         var salt = new byte[SaltSize];
@@ -35,23 +36,6 @@ public sealed class Pbkdf2PasswordHasher : IPasswordHasher
             Convert.ToBase64String(hash));
     }
 
-    
-    private const int KeySize = 32; // 256 bits
-    private const int Iterations = 100_000;
-
-    public string HashPassword(string password)
-    {
-        if (string.IsNullOrEmpty(password))
-        {
-            throw new ArgumentException("Password must not be null or empty.", nameof(password));
-        }
-
-        var salt = RandomNumberGenerator.GetBytes(SaltSize);
-        var hash = Rfc2898DeriveBytes.Pbkdf2(password, salt, Iterations, HashAlgorithmName.SHA256, KeySize);
-
-        return string.Join('.', Iterations.ToString(), Convert.ToBase64String(salt), Convert.ToBase64String(hash));
-    }
-
     public bool VerifyHashedPassword(string hashedPassword, string providedPassword)
     {
         if (string.IsNullOrEmpty(hashedPassword) || string.IsNullOrEmpty(providedPassword))
@@ -59,34 +43,38 @@ public sealed class Pbkdf2PasswordHasher : IPasswordHasher
             return false;
         }
 
-        var parts = hashedPassword.Split('.');
+        var parts = hashedPassword.Split('.', StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length != 3)
         {
             return false;
         }
 
-        if (!int.TryParse(parts[0], out var iterations))
+        if (!int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var iterations))
         {
             return false;
         }
 
+        try
+        {
+            var salt = Convert.FromBase64String(parts[1]);
+            var expected = Convert.FromBase64String(parts[2]);
 
-        var salt = Convert.FromBase64String(segments[1]);
-        var expected = Convert.FromBase64String(segments[2]);
+            var actual = Rfc2898DeriveBytes.Pbkdf2(
+                providedPassword,
+                salt,
+                iterations,
+                HashAlgorithmName.SHA256,
+                expected.Length);
 
-        var actual = Rfc2898DeriveBytes.Pbkdf2(
-
-        var salt = Convert.FromBase64String(parts[1]);
-        var hash = Convert.FromBase64String(parts[2]);
-
-        var computedHash = Rfc2898DeriveBytes.Pbkdf2(
-            providedPassword,
-            salt,
-            iterations,
-            HashAlgorithmName.SHA256,
-            expected.Length);
-
- 
-        return CryptographicOperations.FixedTimeEquals(hash, computedHash);
+            return CryptographicOperations.FixedTimeEquals(expected, actual);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- resolve the merge conflict artifacts in `Pbkdf2PasswordHasher`
- restore the PBKDF2 hashing and verification logic with validation and invariant formatting

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7247f3784833396222c3127bb6450