### PR TITLE
Fix duplicate package references in API project

### DIFF
--- a/src/Parking.Api/Parking.Api.csproj
+++ b/src/Parking.Api/Parking.Api.csproj
@@ -7,16 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.20" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-    <PackageReference Include="QuestPDF" Version="2024.6.3" />
-  </ItemGroup>
-
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.20" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.20" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="QuestPDF" Version="2024.6.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- remove the duplicated Microsoft.AspNetCore.OpenApi and Swashbuckle.AspNetCore package references from Parking.Api
- keep all required packages in a single ItemGroup to ensure consistent restore behavior

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d7a8d78ca48333b93c65cd84efdd55