### PR TITLE
Add CEP lookup endpoint using ViaCEP integration

### DIFF
--- a/src/Parking.Api/Controllers/CepController.cs
+++ b/src/Parking.Api/Controllers/CepController.cs
@@ -1,0 +1,47 @@
+using System.Net.Http;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Parking.Application.Abstractions;
+using Parking.Application.Dtos;
+
+namespace Parking.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[AllowAnonymous]
+public sealed class CepController : ControllerBase
+{
+    private readonly ICepLookupService _cepLookupService;
+
+    public CepController(ICepLookupService cepLookupService)
+    {
+        _cepLookupService = cepLookupService ?? throw new ArgumentNullException(nameof(cepLookupService));
+    }
+
+    [HttpGet("{cep}")]
+    [ProducesResponseType(typeof(CepAddressDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<IActionResult> GetAsync(string cep, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(cep))
+        {
+            return BadRequest("CEP must be provided.");
+        }
+
+        try
+        {
+            var address = await _cepLookupService.GetAddressByCepAsync(cep, cancellationToken);
+            return address is null ? NotFound() : Ok(address);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+        catch (HttpRequestException)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, "Unable to reach CEP service at the moment.");
+        }
+    }
+}

--- a/src/Parking.Application/Abstractions/ICepLookupService.cs
+++ b/src/Parking.Application/Abstractions/ICepLookupService.cs
@@ -1,0 +1,8 @@
+using Parking.Application.Dtos;
+
+namespace Parking.Application.Abstractions;
+
+public interface ICepLookupService
+{
+    Task<CepAddressDto?> GetAddressByCepAsync(string cep, CancellationToken cancellationToken = default);
+}

--- a/src/Parking.Application/Dtos/CepAddressDto.cs
+++ b/src/Parking.Application/Dtos/CepAddressDto.cs
@@ -1,0 +1,13 @@
+namespace Parking.Application.Dtos;
+
+public sealed record CepAddressDto(
+    string Cep,
+    string Street,
+    string? Complement,
+    string Neighborhood,
+    string City,
+    string State,
+    string? Ibge,
+    string? Gia,
+    string? Ddd,
+    string? Siafi);

--- a/src/Parking.Infrastructure/DependencyInjection.cs
+++ b/src/Parking.Infrastructure/DependencyInjection.cs
@@ -5,10 +5,12 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using ApplicationAuthentication = Parking.Application.Authentication;
 using ApplicationSecurity = Parking.Application.Abstractions.Security;
+using Parking.Application.Abstractions;
 using Parking.Domain.Repositories;
 using Parking.Infrastructure.Authentication;
 using Parking.Infrastructure.Persistence;
 using Parking.Infrastructure.Repositories;
+using Parking.Infrastructure.ExternalServices;
 
 namespace Parking.Infrastructure;
 
@@ -71,6 +73,11 @@ public static class DependencyInjection
             static sp => sp.GetRequiredService<JwtTokenGenerator>());
         services.AddSingleton<ApplicationAuthentication.IJwtTokenGenerator>(
             static sp => sp.GetRequiredService<JwtTokenGenerator>());
+
+        services.AddHttpClient<ICepLookupService, ViaCepLookupService>(client =>
+        {
+            client.BaseAddress = new Uri("https://viacep.com.br/");
+        });
 
         return services;
     }

--- a/src/Parking.Infrastructure/ExternalServices/ViaCepLookupService.cs
+++ b/src/Parking.Infrastructure/ExternalServices/ViaCepLookupService.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Parking.Application.Abstractions;
+using Parking.Application.Dtos;
+
+namespace Parking.Infrastructure.ExternalServices;
+
+public sealed class ViaCepLookupService : ICepLookupService
+{
+    private readonly HttpClient _httpClient;
+
+    public ViaCepLookupService(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
+
+    public async Task<CepAddressDto?> GetAddressByCepAsync(string cep, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(cep))
+        {
+            throw new ArgumentException("CEP must be provided.", nameof(cep));
+        }
+
+        var sanitizedCep = SanitizeCep(cep);
+        if (sanitizedCep.Length != 8)
+        {
+            throw new ArgumentException("CEP must contain exactly 8 digits.", nameof(cep));
+        }
+
+        using var response = await _httpClient.GetAsync($"ws/{sanitizedCep}/json/", cancellationToken);
+
+        if (response.StatusCode is HttpStatusCode.BadRequest or HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        var viaCepResponse = await response.Content.ReadFromJsonAsync<ViaCepResponse>(cancellationToken: cancellationToken);
+
+        if (viaCepResponse is null || viaCepResponse.Erro)
+        {
+            return null;
+        }
+
+        return new CepAddressDto(
+            viaCepResponse.Cep ?? sanitizedCep,
+            viaCepResponse.Logradouro ?? string.Empty,
+            viaCepResponse.Complemento,
+            viaCepResponse.Bairro ?? string.Empty,
+            viaCepResponse.Localidade ?? string.Empty,
+            viaCepResponse.Uf ?? string.Empty,
+            viaCepResponse.Ibge,
+            viaCepResponse.Gia,
+            viaCepResponse.Ddd,
+            viaCepResponse.Siafi);
+    }
+
+    private static string SanitizeCep(string cep)
+    {
+        Span<char> buffer = stackalloc char[cep.Length];
+        var count = 0;
+
+        foreach (var ch in cep)
+        {
+            if (char.IsDigit(ch))
+            {
+                buffer[count++] = ch;
+            }
+        }
+
+        return new string(buffer[..count]);
+    }
+
+    private sealed record ViaCepResponse
+    {
+        [JsonPropertyName("cep")]
+        public string? Cep { get; init; }
+
+        [JsonPropertyName("logradouro")]
+        public string? Logradouro { get; init; }
+
+        [JsonPropertyName("complemento")]
+        public string? Complemento { get; init; }
+
+        [JsonPropertyName("bairro")]
+        public string? Bairro { get; init; }
+
+        [JsonPropertyName("localidade")]
+        public string? Localidade { get; init; }
+
+        [JsonPropertyName("uf")]
+        public string? Uf { get; init; }
+
+        [JsonPropertyName("ibge")]
+        public string? Ibge { get; init; }
+
+        [JsonPropertyName("gia")]
+        public string? Gia { get; init; }
+
+        [JsonPropertyName("ddd")]
+        public string? Ddd { get; init; }
+
+        [JsonPropertyName("siafi")]
+        public string? Siafi { get; init; }
+
+        [JsonPropertyName("erro")]
+        public bool Erro { get; init; }
+    }
+}


### PR DESCRIPTION
## Summary
- add an application-level contract and DTO for CEP lookup results
- integrate the ViaCEP HTTP client within infrastructure and wire it up through DI
- expose a public CEP endpoint in the API that queries the ViaCEP service

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d7bf5f410c8333b6e1e51cb97f3a03