### PR TITLE
Add integration with CNPJa Open API

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A documentação interativa (Swagger) estará disponível em `https://localhost:
 - `PUT /api/vehicleinspections/{id}` – atualiza um checklist já registrado.
 - `GET /api/vehicleinspections/{id}` – consulta um checklist específico.
 - `GET /api/vehicleinspections/ticket/{ticketId}` – consulta o checklist vinculado a um ticket.
+- `GET /api/cnpj/{cnpj}` – consulta dados cadastrais de uma empresa via CNPJa Open API.
 
 Os checklists registram o estado visual do veículo (arranhões, itens perdidos, chave perdida e batidas fortes). Sempre que algum item for reprovado (`false`), é obrigatório informar a URL da foto de evidência correspondente.
 
@@ -60,6 +61,13 @@ dotnet test
 ```
 
 Os testes cobrem o cálculo acumulativo de tarifas para garantir a regra de negócio proposta.
+
+## Integração com a CNPJa Open API
+
+A seção `Cnpja` no `appsettings.json` define a URL base e o caminho do recurso para consultas de CNPJ.
+Caso possua um token de acesso, informe-o no campo `Token` (ou defina a variável de ambiente
+`Cnpja__Token`). O endpoint `GET /api/cnpj/{cnpj}` utiliza essas configurações para buscar as
+informações da empresa diretamente na API pública.
 
 ## Instalando o .NET SDK no container
 

--- a/src/Parking.Api/Controllers/CnpjController.cs
+++ b/src/Parking.Api/Controllers/CnpjController.cs
@@ -1,0 +1,61 @@
+using System.Net.Http;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Parking.Api.Mappings;
+using Parking.Api.Models.Responses;
+using Parking.Application.Abstractions;
+
+namespace Parking.Api.Controllers;
+
+[ApiController]
+[Route("api/cnpj")]
+public sealed class CnpjController : ControllerBase
+{
+    private readonly ICnpjLookupService _cnpjLookupService;
+
+    public CnpjController(ICnpjLookupService cnpjLookupService)
+    {
+        _cnpjLookupService = cnpjLookupService;
+    }
+
+    [HttpGet("{cnpj}")]
+    [ProducesResponseType(typeof(CnpjCompanyResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status502BadGateway)]
+    public async Task<ActionResult<CnpjCompanyResponse>> GetByCnpj(string cnpj, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var company = await _cnpjLookupService.GetCompanyAsync(cnpj, cancellationToken);
+            if (company is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(company.ToResponse());
+        }
+        catch (ArgumentException ex)
+        {
+            return Problem(
+                detail: ex.Message,
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Invalid CNPJ provided.");
+        }
+        catch (HttpRequestException ex)
+        {
+            return Problem(
+                detail: ex.Message,
+                statusCode: StatusCodes.Status502BadGateway,
+                title: "CNPJa API returned an error.");
+        }
+        catch (JsonException ex)
+        {
+            return Problem(
+                detail: ex.Message,
+                statusCode: StatusCodes.Status502BadGateway,
+                title: "CNPJa API returned an unexpected payload.");
+        }
+    }
+}

--- a/src/Parking.Api/Mappings/CnpjMappingExtensions.cs
+++ b/src/Parking.Api/Mappings/CnpjMappingExtensions.cs
@@ -1,0 +1,39 @@
+using System.Globalization;
+using Parking.Api.Models.Responses;
+using Parking.Application.Dtos.Cnpj;
+
+namespace Parking.Api.Mappings;
+
+public static class CnpjMappingExtensions
+{
+    public static CnpjCompanyResponse ToResponse(this CnpjCompanyDto dto)
+    {
+        return new CnpjCompanyResponse(
+            dto.Cnpj,
+            dto.CorporateName,
+            dto.TradeName,
+            dto.Status,
+            dto.MainActivity,
+            dto.Email,
+            dto.Phone,
+            dto.FoundedAt?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            dto.Address.ToResponse());
+    }
+
+    public static CnpjCompanyAddressResponse? ToResponse(this CnpjCompanyAddressDto? dto)
+    {
+        if (dto is null)
+        {
+            return null;
+        }
+
+        return new CnpjCompanyAddressResponse(
+            dto.Street,
+            dto.Number,
+            dto.Complement,
+            dto.Neighborhood,
+            dto.City,
+            dto.State,
+            dto.ZipCode);
+    }
+}

--- a/src/Parking.Api/Models/Responses/CnpjCompanyAddressResponse.cs
+++ b/src/Parking.Api/Models/Responses/CnpjCompanyAddressResponse.cs
@@ -1,0 +1,10 @@
+namespace Parking.Api.Models.Responses;
+
+public sealed record CnpjCompanyAddressResponse(
+    string? Street,
+    string? Number,
+    string? Complement,
+    string? Neighborhood,
+    string? City,
+    string? State,
+    string? ZipCode);

--- a/src/Parking.Api/Models/Responses/CnpjCompanyResponse.cs
+++ b/src/Parking.Api/Models/Responses/CnpjCompanyResponse.cs
@@ -1,0 +1,12 @@
+namespace Parking.Api.Models.Responses;
+
+public sealed record CnpjCompanyResponse(
+    string Cnpj,
+    string? CorporateName,
+    string? TradeName,
+    string? Status,
+    string? MainActivity,
+    string? Email,
+    string? Phone,
+    string? FoundedAt,
+    CnpjCompanyAddressResponse? Address);

--- a/src/Parking.Api/appsettings.Development.json
+++ b/src/Parking.Api/appsettings.Development.json
@@ -10,5 +10,10 @@
     "Audience": "Parking.Api",
     "SecretKey": "super-secret-development-key-12345",
     "AccessTokenExpirationMinutes": 60
+  },
+  "Cnpja": {
+    "BaseUrl": "https://api.cnpja.com.br/",
+    "CompanyEndpoint": "companies/{0}",
+    "Token": ""
   }
 }

--- a/src/Parking.Api/appsettings.json
+++ b/src/Parking.Api/appsettings.json
@@ -14,5 +14,10 @@
     "Audience": "Parking.Api",
     "SecretKey": "super-secret-development-key-12345",
     "AccessTokenExpirationMinutes": 60
+  },
+  "Cnpja": {
+    "BaseUrl": "https://api.cnpja.com.br/",
+    "CompanyEndpoint": "companies/{0}",
+    "Token": ""
   }
 }

--- a/src/Parking.Application/Abstractions/ICnpjLookupService.cs
+++ b/src/Parking.Application/Abstractions/ICnpjLookupService.cs
@@ -1,0 +1,8 @@
+using Parking.Application.Dtos.Cnpj;
+
+namespace Parking.Application.Abstractions;
+
+public interface ICnpjLookupService
+{
+    Task<CnpjCompanyDto?> GetCompanyAsync(string cnpj, CancellationToken cancellationToken = default);
+}

--- a/src/Parking.Application/Dtos/Cnpj/CnpjCompanyAddressDto.cs
+++ b/src/Parking.Application/Dtos/Cnpj/CnpjCompanyAddressDto.cs
@@ -1,0 +1,10 @@
+namespace Parking.Application.Dtos.Cnpj;
+
+public sealed record CnpjCompanyAddressDto(
+    string? Street,
+    string? Number,
+    string? Complement,
+    string? Neighborhood,
+    string? City,
+    string? State,
+    string? ZipCode);

--- a/src/Parking.Application/Dtos/Cnpj/CnpjCompanyDto.cs
+++ b/src/Parking.Application/Dtos/Cnpj/CnpjCompanyDto.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Parking.Application.Dtos.Cnpj;
+
+public sealed record CnpjCompanyDto(
+    string Cnpj,
+    string? CorporateName,
+    string? TradeName,
+    string? Status,
+    string? MainActivity,
+    string? Email,
+    string? Phone,
+    DateOnly? FoundedAt,
+    CnpjCompanyAddressDto? Address);

--- a/src/Parking.Infrastructure/ExternalServices/Cnpja/CnpjaOpenApiClient.cs
+++ b/src/Parking.Infrastructure/ExternalServices/Cnpja/CnpjaOpenApiClient.cs
@@ -1,0 +1,298 @@
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Parking.Application.Abstractions;
+using Parking.Application.Dtos.Cnpj;
+
+namespace Parking.Infrastructure.ExternalServices.Cnpja;
+
+internal sealed class CnpjaOpenApiClient : ICnpjLookupService
+{
+    private readonly HttpClient _httpClient;
+    private readonly IOptionsMonitor<CnpjaOptions> _options;
+    private readonly ILogger<CnpjaOpenApiClient> _logger;
+
+    public CnpjaOpenApiClient(
+        HttpClient httpClient,
+        IOptionsMonitor<CnpjaOptions> options,
+        ILogger<CnpjaOpenApiClient> logger)
+    {
+        _httpClient = httpClient;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task<CnpjCompanyDto?> GetCompanyAsync(string cnpj, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(cnpj))
+        {
+            throw new ArgumentException("CNPJ must be provided.", nameof(cnpj));
+        }
+
+        var sanitizedCnpj = new string(cnpj.Where(char.IsDigit).ToArray());
+        if (sanitizedCnpj.Length != 14)
+        {
+            throw new ArgumentException("CNPJ must contain 14 digits.", nameof(cnpj));
+        }
+
+        var options = _options.CurrentValue;
+        var requestPath = BuildCompanyEndpoint(options.CompanyEndpoint, sanitizedCnpj);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, requestPath);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        if (!string.IsNullOrWhiteSpace(options.Token))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", options.Token);
+        }
+
+        using var response = await _httpClient.SendAsync(request, cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            _logger.LogWarning(
+                "CNPJa lookup failed with status code {StatusCode}. Response: {Response}",
+                (int)response.StatusCode,
+                errorBody);
+
+            throw new HttpRequestException(
+                $"CNPJa API returned status code {(int)response.StatusCode}: {errorBody}");
+        }
+
+        await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var document = await JsonDocument.ParseAsync(contentStream, cancellationToken: cancellationToken);
+
+        return MapCompany(document.RootElement);
+    }
+
+    private static string BuildCompanyEndpoint(string? template, string cnpj)
+    {
+        var normalizedTemplate = string.IsNullOrWhiteSpace(template)
+            ? CnpjaOptions.DefaultCompanyEndpoint
+            : template.Trim();
+
+        var path = normalizedTemplate.Contains("{0}", StringComparison.Ordinal)
+            ? string.Format(CultureInfo.InvariantCulture, normalizedTemplate, cnpj)
+            : string.Concat(normalizedTemplate.TrimEnd('/'), "/", cnpj);
+
+        return path.TrimStart('/');
+    }
+
+    private static CnpjCompanyDto MapCompany(JsonElement root)
+    {
+        var cnpjValue = GetString(root, "taxId", "cnpj", "id", "document")
+            ?? throw new JsonException("The CNPJa response did not include a CNPJ identifier.");
+
+        var normalizedCnpj = new string(cnpjValue.Where(char.IsDigit).ToArray());
+        if (normalizedCnpj.Length == 14)
+        {
+            cnpjValue = normalizedCnpj;
+        }
+
+        var corporateName = GetString(root, "name", "razao_social", "corporateName", "businessName");
+        var tradeName = GetString(root, "alias", "nome_fantasia", "tradeName", "fantasyName");
+        var status = GetString(root, "status", "situacao");
+        var foundedAt = GetDate(root, "founded", "foundation", "openingDate", "abertura");
+        var mainActivity = GetMainActivity(root);
+        var email = GetString(root, "email", "emails");
+        var phone = GetString(root, "phone", "phones");
+        var address = MapAddress(root);
+
+        return new CnpjCompanyDto(
+            cnpjValue,
+            corporateName,
+            tradeName,
+            status,
+            mainActivity,
+            email,
+            phone,
+            foundedAt,
+            address);
+    }
+
+    private static CnpjCompanyAddressDto? MapAddress(JsonElement root)
+    {
+        if (!TryGetProperty(root, out var addressElement, "address", "endereco"))
+        {
+            return null;
+        }
+
+        if (addressElement.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        return new CnpjCompanyAddressDto(
+            GetString(addressElement, "street", "logradouro", "addressLine"),
+            GetString(addressElement, "number", "numero"),
+            GetString(addressElement, "complement", "complemento"),
+            GetString(addressElement, "district", "bairro"),
+            GetString(addressElement, "city", "municipio", "cityName"),
+            GetString(addressElement, "state", "uf", "stateCode"),
+            GetString(addressElement, "zip", "cep", "postalCode"));
+    }
+
+    private static string? GetMainActivity(JsonElement root)
+    {
+        if (TryGetProperty(root, out var directActivity, "mainActivity", "primaryActivity", "atividade_principal"))
+        {
+            var value = ConvertToString(directActivity);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        if (TryGetProperty(root, out var activities, "activities", "atividades"))
+        {
+            if (activities.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var activity in activities.EnumerateArray())
+                {
+                    if (activity.ValueKind != JsonValueKind.Object)
+                    {
+                        var candidate = ConvertToString(activity);
+                        if (!string.IsNullOrWhiteSpace(candidate))
+                        {
+                            return candidate;
+                        }
+
+                        continue;
+                    }
+
+                    if (activity.TryGetProperty("isMain", out var isMainElement)
+                        && isMainElement.ValueKind == JsonValueKind.True)
+                    {
+                        var candidate = GetString(activity, "text", "description", "name");
+                        if (!string.IsNullOrWhiteSpace(candidate))
+                        {
+                            return candidate;
+                        }
+                    }
+
+                    var fallback = GetString(activity, "text", "description", "name");
+                    if (!string.IsNullOrWhiteSpace(fallback))
+                    {
+                        return fallback;
+                    }
+                }
+            }
+            else
+            {
+                var candidate = ConvertToString(activities);
+                if (!string.IsNullOrWhiteSpace(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        if (TryGetProperty(root, out var activityObject, "activity"))
+        {
+            var candidate = GetString(activityObject, "text", "description", "name");
+            if (!string.IsNullOrWhiteSpace(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private static DateOnly? GetDate(JsonElement element, params string[] propertyNames)
+    {
+        var text = GetString(element, propertyNames);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return null;
+        }
+
+        text = text.Trim();
+        if (DateOnly.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateOnly))
+        {
+            return dateOnly;
+        }
+
+        var brazilCulture = CultureInfo.GetCultureInfo("pt-BR");
+        if (DateOnly.TryParse(text, brazilCulture, DateTimeStyles.None, out dateOnly))
+        {
+            return dateOnly;
+        }
+
+        if (DateTime.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateTime))
+        {
+            return DateOnly.FromDateTime(dateTime);
+        }
+
+        if (DateTime.TryParse(text, brazilCulture, DateTimeStyles.None, out dateTime))
+        {
+            return DateOnly.FromDateTime(dateTime);
+        }
+
+        return null;
+    }
+
+    private static string? GetString(JsonElement element, params string[] propertyNames)
+    {
+        if (!TryGetProperty(element, out var property, propertyNames))
+        {
+            return null;
+        }
+
+        return ConvertToString(property);
+    }
+
+    private static string? ConvertToString(JsonElement element)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.String:
+                return element.GetString()?.Trim();
+            case JsonValueKind.Number:
+                return element.GetRawText();
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                return element.GetBoolean().ToString();
+            case JsonValueKind.Object:
+                return GetString(element, "text", "description", "value", "name");
+            case JsonValueKind.Array:
+                foreach (var item in element.EnumerateArray())
+                {
+                    var candidate = ConvertToString(item);
+                    if (!string.IsNullOrWhiteSpace(candidate))
+                    {
+                        return candidate;
+                    }
+                }
+
+                break;
+        }
+
+        return null;
+    }
+
+    private static bool TryGetProperty(JsonElement element, out JsonElement property, params string[] propertyNames)
+    {
+        foreach (var propertyName in propertyNames)
+        {
+            if (element.ValueKind == JsonValueKind.Object && element.TryGetProperty(propertyName, out property))
+            {
+                return true;
+            }
+        }
+
+        property = default;
+        return false;
+    }
+}

--- a/src/Parking.Infrastructure/ExternalServices/Cnpja/CnpjaOptions.cs
+++ b/src/Parking.Infrastructure/ExternalServices/Cnpja/CnpjaOptions.cs
@@ -1,0 +1,14 @@
+namespace Parking.Infrastructure.ExternalServices.Cnpja;
+
+public sealed class CnpjaOptions
+{
+    public const string SectionName = "Cnpja";
+    public const string DefaultBaseUrl = "https://api.cnpja.com.br/";
+    public const string DefaultCompanyEndpoint = "companies/{0}";
+
+    public string BaseUrl { get; set; } = DefaultBaseUrl;
+
+    public string CompanyEndpoint { get; set; } = DefaultCompanyEndpoint;
+
+    public string? Token { get; set; }
+}

--- a/src/Parking.Infrastructure/Parking.Infrastructure.csproj
+++ b/src/Parking.Infrastructure/Parking.Infrastructure.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.9" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.2" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- add configurable HTTP client in the infrastructure layer to consume the CNPJa Open API and map responses into application DTOs
- expose a new GET /api/cnpj/{cnpj} endpoint that proxies company lookups and returns normalized response models
- document the new integration and seed default configuration entries for the CNPJa service

## Testing
- dotnet build
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d7bf46a02c833391cbd2fa7381e55a