### PR TITLE
Adiciona endpoint de verificação de SMS via AWS SNS

### DIFF
--- a/docs/aws-sms-integracao.md
+++ b/docs/aws-sms-integracao.md
@@ -1,0 +1,89 @@
+# Integração com Envio de SMS da AWS (Amazon SNS)
+
+Este guia descreve passo a passo como configurar e enviar SMS usando o Amazon Simple Notification Service (SNS). Os passos assumem que você já possui uma conta AWS ativa e privilégios para criar recursos IAM e SNS.
+
+## 1. Preparação do Ambiente
+1. **Crie/acesse uma conta AWS** e faça login no [Console de Gerenciamento AWS](https://console.aws.amazon.com/).
+2. **Defina a região adequada**: escolha uma região suportada para SMS (ex.: `us-east-1`). Algumas regiões limitam recursos de SMS; consulte a [documentação da AWS](https://docs.aws.amazon.com/sns/latest/dg/sns-supported-regions-countries.html).
+3. **Habilite o envio de SMS**: em **Amazon SNS > Text messaging (SMS)** ajuste os limites de gasto e solicite elevação de limites se necessário.
+
+## 2. Configuração de Permissões (IAM)
+1. No console AWS, acesse **IAM > Users** e crie um usuário dedicado ao envio de SMS.
+2. Selecione **Programmatic access** para gerar Access Key e Secret Key.
+3. Anexe a política gerenciada `AmazonSNSFullAccess` ou crie uma política personalizada com permissões mínimas necessárias (`sns:Publish`, `sns:CheckIfPhoneNumberIsOptedOut`, etc.).
+4. Salve as credenciais geradas (Access Key ID e Secret Access Key) para configurar no seu aplicativo.
+
+## 3. Configuração via AWS CLI (opcional)
+1. Instale a [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
+2. Configure com `aws configure` e informe Access Key, Secret Key, região e formato de saída.
+3. Teste o envio com o comando:
+   ```bash
+   aws sns publish \
+     --phone-number "+5511999999999" \
+     --message "Mensagem de teste via Amazon SNS"
+   ```
+   Substitua pelo número no formato E.164 (código do país + número completo).
+
+## 4. Integração em Aplicações (.NET Exemplo)
+1. Adicione o pacote NuGet `AWSSDK.SimpleNotificationService`:
+   ```bash
+   dotnet add package AWSSDK.SimpleNotificationService
+   ```
+2. Configure as credenciais (ex.: via `appsettings.json`, variáveis de ambiente ou `AWS SDK Credential Store`).
+3. Código exemplo:
+   ```csharp
+   using Amazon;
+   using Amazon.SimpleNotificationService;
+   using Amazon.SimpleNotificationService.Model;
+
+   var snsClient = new AmazonSimpleNotificationServiceClient(
+       awsAccessKeyId: "ACCESS_KEY",
+       awsSecretAccessKey: "SECRET_KEY",
+       RegionEndpoint.USEast1);
+
+   var request = new PublishRequest
+   {
+       Message = "Sua mensagem",
+       PhoneNumber = "+5511999999999"
+   };
+
+   await snsClient.PublishAsync(request);
+   ```
+4. Em produção, substitua credenciais hardcoded por provedores seguros (IAM Role, Secrets Manager, Parameter Store, etc.).
+
+## 5. Boas Práticas e Considerações
+- **Opt-in/Opt-out**: garanta consentimento do destinatário e implemente mecanismos de opt-out.
+- **Limites de gastos**: monitore o limite em **SNS > Text messaging (SMS) > Preferences**.
+- **Monitoramento**: utilize CloudWatch para acompanhar métricas e alarmes.
+- **Mensagens transacionais vs promocionais**: verifique restrições regulatórias do país.
+- **Registros e auditoria**: armazene logs de envio e respostas para auditoria e suporte.
+
+## 6. Próximos Passos
+- Automatize envio com tópicos SNS e assinaturas SMS.
+- Integre com filas (SQS) ou lambdas para fluxos assíncronos.
+- Avalie uso de Amazon Pinpoint para campanhas de marketing e analytics avançados.
+
+## 7. Endpoint de Verificação na Parking API
+Com as dependências adicionadas ao projeto, a API passa a expor o endpoint protegido `POST /api/sms/check`.
+
+1. **Configuração**: defina a região e (opcionalmente) credenciais em `appsettings.json` ou via variáveis de ambiente:
+   ```json
+   "Aws": {
+     "Sms": {
+       "Region": "us-east-1",
+       "SenderId": "Parking",
+       "SmsType": "Transactional"
+     }
+   }
+   ```
+   > Se `AccessKey` e `SecretKey` não forem informados, o SDK utilizará os provedores padrão (variáveis `AWS_*`, perfil local, IAM Role, etc.).
+2. **Requisição**: envie um POST autenticado com o corpo:
+   ```json
+   {
+     "phoneNumber": "+5511999999999",
+     "message": "Mensagem de teste do estacionamento."
+   }
+   ```
+3. **Resposta esperada**: `202 Accepted` indicando que a mensagem foi encaminhada para publicação via SNS. Erros de integração retornam `502 Bad Gateway` com detalhes.
+
+Seguindo estes passos, você terá a configuração necessária para enviar SMS via AWS SNS em ambientes de desenvolvimento ou produção.

--- a/src/Parking.Api/Controllers/SmsController.cs
+++ b/src/Parking.Api/Controllers/SmsController.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Parking.Api.Models.Requests;
+using Parking.Application.Abstractions;
+
+namespace Parking.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public sealed class SmsController : ControllerBase
+{
+    private readonly ISmsSender _smsSender;
+    private readonly ILogger<SmsController> _logger;
+
+    public SmsController(ISmsSender smsSender, ILogger<SmsController> logger)
+    {
+        _smsSender = smsSender ?? throw new ArgumentNullException(nameof(smsSender));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [HttpPost("check")]
+    [ProducesResponseType(StatusCodes.Status202Accepted)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status502BadGateway)]
+    public async Task<IActionResult> SendCheckAsync([FromBody] SmsCheckRequest request, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            await _smsSender.SendAsync(request.PhoneNumber, request.Message, cancellationToken);
+            return Accepted(new { request.PhoneNumber, request.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send SMS to {PhoneNumber}", request.PhoneNumber);
+            return Problem(
+                statusCode: StatusCodes.Status502BadGateway,
+                title: "Failed to send SMS.",
+                detail: "Não foi possível enviar a mensagem via SNS. Verifique as configurações e os logs para mais detalhes.");
+        }
+    }
+}

--- a/src/Parking.Api/Models/Requests/SmsCheckRequest.cs
+++ b/src/Parking.Api/Models/Requests/SmsCheckRequest.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Parking.Api.Models.Requests;
+
+public sealed class SmsCheckRequest
+{
+    [Required]
+    [Phone]
+    public string PhoneNumber { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(160)]
+    public string Message { get; set; } = "Mensagem de teste do estacionamento.";
+}

--- a/src/Parking.Api/appsettings.Development.json
+++ b/src/Parking.Api/appsettings.Development.json
@@ -10,5 +10,12 @@
     "Audience": "Parking.Api",
     "SecretKey": "super-secret-development-key-12345",
     "AccessTokenExpirationMinutes": 60
+  },
+  "Aws": {
+    "Sms": {
+      "Region": "us-east-1",
+      "SenderId": "Parking",
+      "SmsType": "Transactional"
+    }
   }
 }

--- a/src/Parking.Api/appsettings.json
+++ b/src/Parking.Api/appsettings.json
@@ -14,5 +14,12 @@
     "Audience": "Parking.Api",
     "SecretKey": "super-secret-development-key-12345",
     "AccessTokenExpirationMinutes": 60
+  },
+  "Aws": {
+    "Sms": {
+      "Region": "us-east-1",
+      "SenderId": "Parking",
+      "SmsType": "Transactional"
+    }
   }
 }

--- a/src/Parking.Application/Abstractions/ISmsSender.cs
+++ b/src/Parking.Application/Abstractions/ISmsSender.cs
@@ -1,0 +1,6 @@
+namespace Parking.Application.Abstractions;
+
+public interface ISmsSender
+{
+    Task SendAsync(string phoneNumber, string message, CancellationToken cancellationToken = default);
+}

--- a/src/Parking.Infrastructure/Messaging/AwsSmsOptions.cs
+++ b/src/Parking.Infrastructure/Messaging/AwsSmsOptions.cs
@@ -1,0 +1,18 @@
+namespace Parking.Infrastructure.Messaging;
+
+public sealed record AwsSmsOptions
+{
+    public const string SectionName = "Aws:Sms";
+
+    public required string Region { get; init; }
+
+    public string? AccessKey { get; init; }
+
+    public string? SecretKey { get; init; }
+
+    public string? SenderId { get; init; }
+
+    public string? SmsType { get; init; }
+
+    public string? MaxPrice { get; init; }
+}

--- a/src/Parking.Infrastructure/Messaging/AwsSmsSender.cs
+++ b/src/Parking.Infrastructure/Messaging/AwsSmsSender.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Parking.Application.Abstractions;
+
+namespace Parking.Infrastructure.Messaging;
+
+public sealed class AwsSmsSender : ISmsSender
+{
+    private readonly IAmazonSimpleNotificationService _snsClient;
+    private readonly AwsSmsOptions _options;
+    private readonly ILogger<AwsSmsSender> _logger;
+
+    public AwsSmsSender(
+        IAmazonSimpleNotificationService snsClient,
+        IOptions<AwsSmsOptions> options,
+        ILogger<AwsSmsSender> logger)
+    {
+        _snsClient = snsClient;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task SendAsync(string phoneNumber, string message, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(phoneNumber);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
+        var request = new PublishRequest
+        {
+            PhoneNumber = phoneNumber,
+            Message = message,
+        };
+
+        var attributes = request.MessageAttributes ??= new Dictionary<string, MessageAttributeValue>();
+
+        if (!string.IsNullOrWhiteSpace(_options.SenderId))
+        {
+            attributes["AWS.SNS.SMS.SenderID"] = new MessageAttributeValue
+            {
+                DataType = "String",
+                StringValue = _options.SenderId
+            };
+        }
+
+        if (!string.IsNullOrWhiteSpace(_options.SmsType))
+        {
+            attributes["AWS.SNS.SMS.SMSType"] = new MessageAttributeValue
+            {
+                DataType = "String",
+                StringValue = _options.SmsType
+            };
+        }
+
+        if (!string.IsNullOrWhiteSpace(_options.MaxPrice))
+        {
+            attributes["AWS.SNS.SMS.MaxPrice"] = new MessageAttributeValue
+            {
+                DataType = "Number",
+                StringValue = _options.MaxPrice
+            };
+        }
+
+        try
+        {
+            await _snsClient.PublishAsync(request, cancellationToken);
+        }
+        catch (AmazonSimpleNotificationServiceException ex)
+        {
+            _logger.LogError(ex, "Failed to send SMS via AWS SNS.");
+            throw;
+        }
+    }
+}

--- a/src/Parking.Infrastructure/Parking.Infrastructure.csproj
+++ b/src/Parking.Infrastructure/Parking.Infrastructure.csproj
@@ -6,6 +6,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />


### PR DESCRIPTION
## Summary
- adiciona interface de envio de SMS e implementação via AWS SNS
- expõe rota POST /api/sms/check para disparo de SMS de checagem
- documenta configuração necessária em appsettings e no guia de integração

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d7bec3d1988333afbe6b854f4e76e6