### PR TITLE
Atualiza exportação de tickets em PDF

### DIFF
--- a/src/Parking.Api/Controllers/TicketsController.cs
+++ b/src/Parking.Api/Controllers/TicketsController.cs
@@ -83,10 +83,23 @@ public sealed class TicketsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<IActionResult> ExportAsPdfAsync(CancellationToken cancellationToken)
     {
-        var tickets = await _parkingTicketService.GetAllTicketsAsync(cancellationToken);
-        var pdfBytes = _ticketPdfExporter.Generate(tickets);
-        var fileName = $"tickets-{DateTimeOffset.UtcNow:yyyyMMddHHmmss}.pdf";
-        return File(pdfBytes, "application/pdf", fileName);
+        try
+        {
+            var tickets = await _parkingTicketService.GetAllTicketsAsync(cancellationToken);
+            var pdfBytes = _ticketPdfExporter.Generate(tickets);
+            var fileName = $"tickets-{DateTimeOffset.UtcNow:yyyyMMddHHmmss}.pdf";
+            return File(pdfBytes, "application/pdf", fileName);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            var pdfBytes = _ticketPdfExporter.GenerateError();
+            var fileName = $"tickets-error-{DateTimeOffset.UtcNow:yyyyMMddHHmmss}.pdf";
+            return File(pdfBytes, "application/pdf", fileName);
+        }
     }
 
     [HttpPost("filter")]

--- a/src/Parking.Api/Services/ITicketPdfExporter.cs
+++ b/src/Parking.Api/Services/ITicketPdfExporter.cs
@@ -5,4 +5,6 @@ namespace Parking.Api.Services;
 public interface ITicketPdfExporter
 {
     byte[] Generate(IReadOnlyCollection<ParkingTicketDto> tickets);
+
+    byte[] GenerateError();
 }


### PR DESCRIPTION
## Summary
- atualiza o exportador de PDF para usar os novos assets de plano de fundo em relatórios e estados sem dados
- adiciona geração de PDF com layout de erro quando a busca por tickets falha e o controller trata a exceção
- estende a interface de exportação para suportar a geração de PDFs de erro

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d7d6886ff08333a72c02e6d9535548